### PR TITLE
Plumb in functionality to choose keychain.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+all:
+
+cscope:
+	@echo "Creating cscope database"
+	-@rm -f ./cscope.files ./cscope.out
+	@find . -iname "*go" > cscope.files
+	@cscope -q -b -k -i ./cscope.files
+

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,10 @@
-module github.com/keybase/go-keychain
+module github.com/uttie-huntress/go-keychain
 
 go 1.19
 
 require (
 	github.com/keybase/dbus v0.0.0-20220506165403-5aa21ea2c23a
+	github.com/keybase/go-keychain v0.0.0-20230523030712-b5615109f100
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.0
 	golang.org/x/crypto v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/keybase/dbus v0.0.0-20220506165403-5aa21ea2c23a h1:K0EAzgzEQHW4Y5lxrmvPMltmlRDzlhLfGmots9EHUTI=
 github.com/keybase/dbus v0.0.0-20220506165403-5aa21ea2c23a/go.mod h1:YPNKjjE7Ubp9dTbnWvsP3HT+hYnY6TfXzubYTBeUxc8=
+github.com/keybase/go-keychain v0.0.0-20230523030712-b5615109f100 h1:rG3VnJUnAWyiv7qYmmdOdSapzz6HM+zb9/uRFr0T5EM=
+github.com/keybase/go-keychain v0.0.0-20230523030712-b5615109f100/go.mod h1:qDHUvIjGZJUtdPtuP4WMu5/U4aVWbFw1MhlkJqCGmCQ=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/keychain.go
+++ b/keychain.go
@@ -67,6 +67,8 @@ var (
 	ErrorInvalidOwnerEdit = Error(C.errSecInvalidOwnerEdit)
 	// ErrorUserCanceled corresponds to errSecUserCanceled result code
 	ErrorUserCanceled = Error(C.errSecUserCanceled)
+	// ErrorSecWrPerm corresponds to errSecWrPerm result code
+	ErrorSecWrPerm = Error(C.errSecWrPerm)
 )
 
 func checkError(errCode C.OSStatus) error {
@@ -124,6 +126,8 @@ func (k Error) Error() (msg string) {
 		msg = "An invalid attempt to change the owner of an item."
 	case ErrorUserCanceled:
 		msg = "User canceled the operation."
+	case ErrorSecWrPerm:
+		msg = "Write permissions error"
 	default:
 		msg = "Keychain Error."
 	}

--- a/keychain_ext.go
+++ b/keychain_ext.go
@@ -1,0 +1,70 @@
+//go:build darwin
+// +build darwin
+
+package keychain
+
+// See https://developer.apple.com/library/ios/documentation/Security/Reference/keychainservices/index.html for the APIs used below.
+
+// Also see https://developer.apple.com/library/ios/documentation/Security/Conceptual/keychainServConcepts/01introduction/introduction.html .
+
+/*
+#cgo LDFLAGS: -framework CoreFoundation -framework Security
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <Security/Security.h>
+*/
+import "C"
+import (
+	"unsafe"
+)
+
+// Keychain represents the path to a specific OSX keychain
+type Keychain struct {
+	path string
+}
+
+func NewKeychain(path string) Keychain {
+	return Keychain{path: path}
+}
+
+// The returned SecKeychainRef, if non-nil, must be released via CFRelease.
+func openKeychainRef(path string) (C.SecKeychainRef, error) {
+	pathName := C.CString(path)
+	defer C.free(unsafe.Pointer(pathName))
+
+	var kref C.SecKeychainRef
+	if err := checkError(C.SecKeychainOpen(pathName, &kref)); err != nil {
+		return 0, err
+	}
+	return kref, nil
+}
+
+// The returned CFTypeRef, if non-nil, must be released via CFRelease.
+func (kc Keychain) Convert() (C.CFTypeRef, error) {
+	keyRef, err := openKeychainRef(kc.path)
+	return C.CFTypeRef(keyRef), err
+}
+
+var KeychainKey = attrKey(C.CFTypeRef(C.kSecUseKeychain))
+
+func (k *Item) UseKeychain(kc Keychain) {
+	k.attr[KeychainKey] = kc
+}
+
+// Status returns the status of the keychain
+func (kc Keychain) Status() error {
+	// returns no error even if it doesn't exist
+	kref, err := openKeychainRef(kc.path)
+	if err != nil {
+		return err
+	}
+	defer C.CFRelease(C.CFTypeRef(kref))
+
+	var status C.SecKeychainStatus
+	return checkError(C.SecKeychainGetStatus(kref, &status))
+}
+
+// releaseKey releases the memory - used for testing
+func releaseKey(kref C.SecKeychainRef) {
+	Release(C.CFTypeRef(kref))
+}

--- a/keychain_ext_test.go
+++ b/keychain_ext_test.go
@@ -1,0 +1,41 @@
+//go:build darwin
+// +build darwin
+
+package keychain
+
+import (
+	"fmt"
+	"testing"
+)
+
+func setUp() {
+
+	// Create keychain
+	// security create-keychain -p "" "blah"
+
+	// return keychain
+}
+
+func tearDown() {
+
+	// Delete keychain
+	// security delete-keychain MyNew.keychain
+
+}
+
+func TestValidOpenKeychain(t *testing.T) {
+
+	testKeychainPath := "/Users/uttie/Library/Keychains/login.keychain"
+	testKeychain := Keychain{path: testKeychainPath}
+	kref, err := openKeychainRef(testKeychain.path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if kref == 0 {
+		t.Fatal("keychain is null")
+	}
+
+	fmt.Println(testKeychain.Status())
+	//releaseKey(kref)
+}


### PR DESCRIPTION
This functionality allows access to keychain of choice, the primary reason is to target System keychain as a place to store items. It consciously uses a deprecated SecKeychainOpen call, because that's, at present, the only way to access that keychain.

It is deprecated, though the DTS at apple forums suggest something similar to this for LaunchDaemons to have access to the keychain.